### PR TITLE
Remove Link header which is sends with preconnect from server

### DIFF
--- a/httpd.conf
+++ b/httpd.conf
@@ -579,6 +579,7 @@ FilterProvider Compress DEFLATE true
     Header unset Accept-Encoding 
     Header unset Content-Security-Policy-Report-Only
     Header unset Report-To
+    Header unset link
 
     RequestHeader unset Accept-Encoding
     RequestHeader unset X-forwarded-for
@@ -606,6 +607,7 @@ FilterProvider Compress DEFLATE true
     Header unset Accept-Encoding 
     Header unset Content-Security-Policy-Report-Only
     Header unset Report-To
+    Header unset link
 
     RequestHeader unset Accept-Encoding
     RequestHeader unset X-forwarded-for


### PR DESCRIPTION
Unset link header which is send with preconnect from server
link: <https://fonts.gstatic.com>; rel=preconnect; crossorigin